### PR TITLE
Report streamed body size and total time to the access log

### DIFF
--- a/include/AsyncConnection.h
+++ b/include/AsyncConnection.h
@@ -328,8 +328,22 @@ class AsyncConnection : public Connection, public std::enable_shared_from_this<A
 
   void notifyClientDisconnect(const boost::system::error_code& e, std::size_t bytes_transferred);
 
-  /// Number of sent bytes so far
+  // ======================================================================
+  /*!
+   * \brief Fire the response's deferred access-log finalizer (if any) with
+   * the total number of body bytes streamed. Runs at most once; safe to
+   * call from every stream terminal path (normal completion and errors).
+   */
+  // ======================================================================
+
+  void finalizeStreamLogging();
+
+  /// Number of sent bytes so far (within the current chunk)
   std::size_t itsSentBytes;
+
+  /// Total response body bytes streamed across all chunks, for deferred
+  /// access logging of streamed/chunked responses.
+  std::size_t itsTotalStreamedBytes = 0;
 
   /// Handle to the server instance which spawned this connection
   /* AsyncServer* itsServer; */

--- a/smartmet-server.spec
+++ b/smartmet-server.spec
@@ -2,8 +2,8 @@
 %define SPECNAME smartmet-%{DIRNAME}
 Summary: SmartMet HTTP server
 Name: %{SPECNAME}
-Version: 26.4.16
-Release: 2%{?dist}.fmi
+Version: 26.6.15
+Release: 1%{?dist}.fmi
 License: MIT
 Group: System Environment/Daemons
 URL: https://github.com/fmidev/smartmet-server
@@ -107,6 +107,16 @@ for dir in %{_localstatedir}/log/smartmet %{_localstatedir}/smartmet /brainstorm
 done
 
 %changelog
+* Mon Jun 15 2026 Mika Heiskanen <mika.heiskanen@fmi.fi> 26.6.15-1.fmi
+- Streamed/chunked responses now log the real body size and total
+  execution time. AsyncConnection accumulates the body bytes sent
+  across all chunks (excluding chunk framing) and, once the final
+  chunk has been sent (or the stream aborts on a send error / client
+  disconnect), fires the Response's deferred access-log finalizer
+  with that total. Previously a streamed download logged a bogus
+  byte count and only its handler-setup time. Requires
+  smartmet-library-spine >= 26.6.15.
+
 * Thu Apr 16 2026 Andris Pavēnis <andris.pavenis@fmi.fi> 26.4.16-2.fmi
 - Add optional períodic logging of used memory amount
 

--- a/source/AsyncConnection.cpp
+++ b/source/AsyncConnection.cpp
@@ -655,6 +655,8 @@ void AsyncConnection::writeChunkedReply(const boost::system::error_code& e,
       sendStockReply(SmartMet::Spine::HTTP::Status::service_unavailable);
       reportInfo("Error in chunked reply send to " + itsRequest->getClientIP() +
                  ". Reason: " + e.message() + ". Code: " + Fmi::to_string(e.value()));
+      // Log the aborted stream with the bytes delivered so far.
+      finalizeStreamLogging();
     }
   }
   catch (...)
@@ -698,14 +700,19 @@ void AsyncConnection::finalizeChunkedReply(const boost::system::error_code& e,
                                     { me->finalizeChunkedReply(err, bytes_transferred); });
         }
       }
-
-      // Implicit else here, this was the final chunk so stop scheduling async writes
+      else
+      {
+        // Final chunk has been sent — the streamed response is complete.
+        finalizeStreamLogging();
+      }
     }
     else
     {
       sendStockReply(SmartMet::Spine::HTTP::Status::service_unavailable);
       reportInfo("Error in finalizing chunked reply send to " + itsRequest->getClientIP() +
                  ". Reason: " + e.message() + ". Code: " + Fmi::to_string(e.value()));
+      // Log the aborted stream with the bytes delivered so far.
+      finalizeStreamLogging();
     }
   }
   catch (...)
@@ -730,6 +737,9 @@ void AsyncConnection::getNextChunk()
 
       if (!contentstring.empty())
       {
+        // Account this chunk's body bytes for the deferred access log.
+        itsTotalStreamedBytes += contentstring.size();
+
         // Send received data
         itsResponseString = contentstring;
 
@@ -760,7 +770,10 @@ void AsyncConnection::getNextChunk()
     }
     else
     {
-      // Stream status is EXIT, finalize the send
+      // Stream status is EXIT, finalize the send. The streamed response is
+      // complete: write the deferred access-log entry with the real size.
+      finalizeStreamLogging();
+
       if (itsResponse->isGatewayResponse)
       {
         // If the response is a gateway response (sent by frontend plugin) call the associated hooks
@@ -792,6 +805,13 @@ void AsyncConnection::getNextChunkedChunk()
       if (!contentstring.empty())
       {
         std::size_t length = contentstring.size();
+
+        // Account this chunk's body bytes for the deferred access log.
+        // The hex length + CRLF framing is transport overhead and is
+        // deliberately excluded so the logged size matches the response
+        // body size, like non-chunked responses.
+        itsTotalStreamedBytes += length;
+
         std::string hexlength = convertToHex(length);
         std::string responsestring = hexlength + "\r\n" + contentstring + "\r\n";
 
@@ -900,6 +920,8 @@ void AsyncConnection::writeStreamReply(const boost::system::error_code& e,
       sendStockReply(SmartMet::Spine::HTTP::Status::service_unavailable);
       reportInfo("Error in stream reply send to " + itsRequest->getClientIP() +
                  ". Reason: " + e.message());
+      // Log the aborted stream with the bytes delivered so far.
+      finalizeStreamLogging();
       if (itsResponse->isGatewayResponse)
       {
         // If the response is a gateway response (sent by frontend plugin) call the associated hooks
@@ -967,6 +989,25 @@ void AsyncConnection::writeRegularReply(const boost::system::error_code& e,
     Fmi::Exception ex(BCP, "Operation failed! AsyncConnection::writeRegularReply aborted", nullptr);
     std::cerr << ex.getStackTrace();
     // std::cerr << "Operation failed! AsyncConnection::writeRegularReply aborted\n";
+  }
+}
+
+// Fire the response's deferred access-log finalizer with the total body
+// bytes streamed. Runs at most once (the handler removes itself), so this
+// is safe to call from every stream terminal path: normal completion, send
+// errors, and client disconnects. No-op for responses that did not register
+// a finalizer (non-streamed, or logging disabled for the handler).
+void AsyncConnection::finalizeStreamLogging()
+{
+  try
+  {
+    if (itsResponse)
+      itsResponse->runStreamCompletionHandler(itsTotalStreamedBytes);
+  }
+  catch (...)
+  {
+    Fmi::Exception ex(BCP, "Operation failed! AsyncConnection::finalizeStreamLogging", nullptr);
+    std::cerr << ex.getStackTrace();
   }
 }
 


### PR DESCRIPTION
## Summary
`AsyncConnection` now accumulates the total response body bytes across all chunks (excluding chunk framing) and fires the `Response`'s deferred access-log finalizer at every stream terminal point: normal completion (chunked and non-chunked) and the abort paths (send error / client disconnect), so a cancelled download still logs the bytes delivered so far.

Streamed downloads therefore log the **real size** and the **full duration** instead of a bogus byte count and handler-setup-only time. (The timeout timer is cancelled before streaming begins, so client disconnects surface as write errors and are covered by the abort branches.)

## Cross-repo dependency
Requires **smartmet-library-spine >= 26.6.15** (companion `download-access-log-fix` PR) for the `setStreamCompletionHandler` / `runStreamCompletionHandler` API. **Land together, spine first.**

## Test plan
- The changed translation unit compiles cleanly against the new spine API.
- Live download smoke test pending deploy (install updated spine, then server; hit a `/download` endpoint and confirm the access log shows real size + full duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)