### PR TITLE
docs: document client reverse-DNS resolution options in sample config

### DIFF
--- a/cnf/smartmet.conf.sample
+++ b/cnf/smartmet.conf.sample
@@ -42,6 +42,29 @@ lazylinking = false;
 
 defaultlogging = true;
 
+// Reverse-DNS (PTR) resolution of the client IP for the "-HostName:" field of
+// the request log. Resolution is cached and time-bounded and runs off the
+// request thread, so a slow or missing PTR record never delays a response.
+//
+//   resolveclienthostname      master switch; set false to log the raw client
+//                              IP only and skip the PTR lookup entirely
+//                              (default true)
+//   clienthostnametimeout      max milliseconds a request waits for a fresh
+//                              lookup before logging the IP only; 0 = fully
+//                              asynchronous, never wait (default 200)
+//   clienthostnamecachesize    max cached IP -> host name entries, LRU
+//                              (default 10000)
+//   clienthostnamepositivettl  seconds a successful lookup stays cached
+//                              (default 3600)
+//   clienthostnamenegativettl  seconds a failed/timed-out lookup stays cached
+//                              (default 60)
+
+resolveclienthostname = true;
+clienthostnametimeout = 200;
+// clienthostnamecachesize   = 10000;
+// clienthostnamepositivettl = 3600;
+// clienthostnamenegativettl = 60;
+
 debug	       	= false;
 verbose		= true;
 


### PR DESCRIPTION
## What

Documents the new client reverse-DNS (PTR) resolution settings in
`cnf/smartmet.conf.sample`:

```
resolveclienthostname = true;   // false => log raw client IP only, no PTR lookup
clienthostnametimeout = 200;    // ms a request waits for a fresh lookup; 0 = async
// clienthostnamecachesize   = 10000;
// clienthostnamepositivettl = 3600;
// clienthostnamenegativettl = 60;
```

## Why

The `-HostName:` field of the request log is filled by a reverse-DNS lookup of
the client IP. Historically that lookup was synchronous and unbounded on the
request thread, so a slow or missing client PTR record stalled the whole
request for the full DNS timeout (~5 s).

The fix lives in spine
(**fmidev/smartmet-library-spine#45**), which makes the lookup bounded,
cached and non-blocking and adds these options to `Spine::Options`. This PR is
**docs-only** — it just surfaces the new keys in the server's sample config.

The settings are parsed via `lookupHostSetting`, so unknown keys are ignored by
older spine builds; adding them here is safe regardless of spine version, but
they only take effect once spine #45 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)